### PR TITLE
Explicitly cast tinyint as int

### DIFF
--- a/Music.class.php
+++ b/Music.class.php
@@ -129,7 +129,7 @@ class Music implements \BMO {
 		$sth = $this->db->prepare($sql);
 		$sth->execute(array(
 			"type" => $type,
-			"random" => $random,
+			"random" => (int) $random,
 			"application" => $application,
 			"format" => $format,
 			"id" => $id


### PR DESCRIPTION
Fix error 
SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `asterisk`.`music`.`random` at row 1 File:/var/www/html/freepbx/admin/modules/music/Music.class.php:135

refs: https://community.freepbx.org/t/music-on-hold-bug-incorrect-data-for-application-submission/94391