### PR TITLE
don't create existing directory

### DIFF
--- a/Restore.php
+++ b/Restore.php
@@ -26,7 +26,9 @@ class Restore Extends Base\RestoreBase{
 			$source = $this->tmpdir.'/files'.$file->getPathTo().'/'.$file->getFilename();
 			$dest = $filename;
 			if(file_exists($source)){
-				@mkdir($file->getPathTo(),0755,true);
+				if (!file_exists($file->getPathTo())) {
+					mkdir($file->getPathTo(),0755,true);
+				}
 				copy($source, $dest);
 			}
 


### PR DESCRIPTION
Correct warnings seen during restore:
```none
PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/music/Restore.php on line 29

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/music/Restore.php on line 29

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/music/Restore.php on line 29

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/music/Restore.php on line 29

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/music/Restore.php on line 29

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/music/Restore.php on line 29

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/music/Restore.php on line 29

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/music/Restore.php on line 29
```